### PR TITLE
Change String to TranslatableText

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,33 @@
-# Project exclude paths
-/.gradle/
+# gradle
+
+.gradle/
+build/
+out/
+classes/
+
+# eclipse
+
+*.launch
+
+# idea
+
+.idea/
+*.iml
+*.ipr
+*.iws
+
+# vscode
+
+.settings/
+.vscode/
+bin/
+.classpath
+.project
+
+# macos
+
+*.DS_Store
+
+# fabric
+
+run/

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-7.1-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-7.3-bin.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists

--- a/src/main/java/ch/skyfy/tipsandtricks/Data.java
+++ b/src/main/java/ch/skyfy/tipsandtricks/Data.java
@@ -1,12 +1,14 @@
 package ch.skyfy.tipsandtricks;
 
+import net.minecraft.text.TranslatableText;
+
 import java.util.ArrayList;
 import java.util.List;
 
 public class Data {
-    public static final List<String> TIPS = new ArrayList<>(){{
-        add("The best level to find diamond is 11");
-        add("The best fuel source is a Lava bucket");
-        add("If you wear a Pumpkin, then Endermen will not attack you");
+    public static final List<TranslatableText> TIPS = new ArrayList<>(){{
+        for (int i = 0; i < 3; i++) {
+            add(new TranslatableText("tipsandtricks.tip."+i));
+        }
     }};
 }

--- a/src/main/java/ch/skyfy/tipsandtricks/TipsAndTricks.java
+++ b/src/main/java/ch/skyfy/tipsandtricks/TipsAndTricks.java
@@ -4,6 +4,7 @@ import net.fabricmc.api.ModInitializer;
 import net.fabricmc.fabric.api.command.v1.CommandRegistrationCallback;
 import net.fabricmc.fabric.api.event.lifecycle.v1.ServerEntityEvents;
 import net.minecraft.server.network.ServerPlayerEntity;
+import net.minecraft.text.TranslatableText;
 
 import java.util.ArrayList;
 import java.util.Collections;
@@ -27,7 +28,7 @@ public class TipsAndTricks implements ModInitializer {
         CommandRegistrationCallback.EVENT.register((dispatcher, dedicated) -> CmdDisableTips.register(dispatcher));
     }
 
-    public static List<String> shuffle() {
+    public static List<TranslatableText> shuffle() {
         var list = new ArrayList<>(Data.TIPS);
         Collections.shuffle(list);
         return list;

--- a/src/main/java/ch/skyfy/tipsandtricks/TipsPlayer.java
+++ b/src/main/java/ch/skyfy/tipsandtricks/TipsPlayer.java
@@ -4,6 +4,7 @@ import net.minecraft.client.MinecraftClient;
 import net.minecraft.server.network.ServerPlayerEntity;
 import net.minecraft.sound.SoundCategory;
 import net.minecraft.sound.SoundEvents;
+import net.minecraft.text.TranslatableText;
 
 import java.util.*;
 
@@ -11,14 +12,14 @@ public class TipsPlayer {
 
     private final ServerPlayerEntity player;
 
-    private final List<String> shuffledTips;
+    private final List<TranslatableText> shuffledTips;
 
     private final Timer timer;
 
     //        private int delay = new Random().nextInt(7_200_00, 10_800_000); // Between 2 hours and 3 hours in millis
     private final int delay = new Random().nextInt(30000, 60000); // test
 
-    public TipsPlayer(ServerPlayerEntity player, List<String> shuffledTips) {
+    public TipsPlayer(ServerPlayerEntity player, List<TranslatableText> shuffledTips) {
         this.player = player;
         this.shuffledTips = shuffledTips;
         timer = new Timer();
@@ -44,7 +45,7 @@ public class TipsPlayer {
         }, delay, delay);
     }
 
-    private void announce(String tip) {
+    private void announce(TranslatableText tip) {
         // Play a sound
         player.getWorld().playSound(null, player.getBlockPos(), SoundEvents.BLOCK_ANVIL_FALL, SoundCategory.BLOCKS, 1f, 1f);
 

--- a/src/main/java/ch/skyfy/tipsandtricks/TipsToast.java
+++ b/src/main/java/ch/skyfy/tipsandtricks/TipsToast.java
@@ -3,18 +3,19 @@ package ch.skyfy.tipsandtricks;
 import net.minecraft.client.toast.Toast;
 import net.minecraft.client.toast.ToastManager;
 import net.minecraft.client.util.math.MatrixStack;
+import net.minecraft.text.TranslatableText;
 
 public class TipsToast implements Toast{
 
-    private final String tip;
+    private final TranslatableText tip;
 
-    public TipsToast(String tip) {
+    public TipsToast(TranslatableText tip) {
         this.tip = tip;
     }
 
     @Override
     public Visibility draw(MatrixStack matrices, ToastManager manager, long startTime) {
-        return null;
+        return Visibility.SHOW;
     }
 
     @Override

--- a/src/main/resources/assets/tipsandtricks/lang/en_us.json
+++ b/src/main/resources/assets/tipsandtricks/lang/en_us.json
@@ -1,0 +1,5 @@
+{
+  "tipsandtricks.tip.0": "The best level to find diamond is 11",
+  "tipsandtricks.tip.1": "The best fuel source is a Lava bucket",
+  "tipsandtricks.tip.2": "If you wear a Pumpkin, then Endermen will not attack you"
+}

--- a/src/main/resources/fabric.mod.json
+++ b/src/main/resources/fabric.mod.json
@@ -1,6 +1,6 @@
 {
   "schemaVersion": 1,
-  "id": "tipsandtrick",
+  "id": "tipsandtricks",
   "version": "${version}",
 
   "name": "tipsandtrick",


### PR DESCRIPTION
This PR allows resource packs to change the tips, supporting other languages and customization without needing to code. It also updates gradle to 7.3 (which is required to compile on Java 17), changes the modid to be the same as the filepath name (otherwise this mod wouldn't load at all), returns Visibility.SHOW instead of null for the draw() override (the game crashes if is it null), and added more directories and file endings to the .gitignore.

The number of tips is currently hardcoded to 3, just as it was before. I left it up to you on how to make it dynamically editable, whether it be via in-game command, datapacks, or config. Just change the 3 in the for loop to whatever.